### PR TITLE
Fix streaming compression and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,16 @@ I created this library for my I Drive project.
 
 If you have a different use case scenario, and LocalFile and GenFile are not enough, you can extend BaseFile and everything else should work out of the box.
 
+### Testing
 
+With [pytest](https://docs.pytest.org/en/stable/) and
+[pytest-asyncio](https://pytest-asyncio.readthedocs.io/en/stable/) installed,
+call `pytest` from the top-level directory (same as this `README.md`)
+to run tests.
+The 4GB tests are slow. If your machine has enough memory (~4GB free) and a fast
+disk/SSD, [pytest-xdist](https://pytest-xdist.readthedocs.io/en/stable/)
+can speed things up by running tests in parallel.
+Use it by calling `pytest -n auto`.
 
 ### PS
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ exclude = [
     "venv",
 ]
 
-line-length = 80
+line-length = 190
 indent-width = 4
 
 # Assume Python 3.9

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,3 +25,88 @@ requires-python = ">=3.7"
 [project.urls]
 Github = "https://github.com/pam-param-pam/ZipFly"
 
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "-ra -q"
+testpaths = [
+    "tests",
+]
+
+[tool.ruff]
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+]
+
+line-length = 80
+indent-width = 4
+
+# Assume Python 3.9
+target-version = "py39"
+
+[tool.ruff.lint]
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
+# Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
+# McCabe complexity (`C901`) by default.
+select = ["E4", "E7", "E9", "F" ,"ALL"]
+ignore = []
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+# Disable fix for unused imports (`F401`).
+unfixable = ["F401"]
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.ruff.format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"
+
+# Enable auto-formatting of code examples in docstrings. Markdown,
+# reStructuredText code/literal blocks and doctests are all supported.
+#
+# This is currently disabled by default, but it is planned for this
+# to be opt-out in the future.
+docstring-code-format = false
+
+# Set the line length limit used when formatting code snippets in
+# docstrings.
+#
+# This only has an effect when the `docstring-code-format` setting is
+# enabled.
+docstring-code-line-length = "dynamic"
+

--- a/src/zipFly/BaseFile.py
+++ b/src/zipFly/BaseFile.py
@@ -13,18 +13,14 @@ class BaseFile(ABC):
         self.__offset = 0  # Offset to local file header
         self.__crc = 0
         self.__compression_method = compression_method or consts.NO_COMPRESSION
-        self.__flags = (
-            0b00001000  # flag about using data descriptor is always on
-        )
+        self.__flags = 0b00001000  # flag about using data descriptor is always on
 
     def __str__(self):
         return f"FILE[{self.name}]"
 
     def generate_processed_file_data(self) -> Generator[bytes, None, None]:
         if self.__used:
-            raise KeyError(
-                "ERROR: This file has already been used for streaming",
-            )
+            raise KeyError("ERROR: This file has already been used for streaming")
         self.__used = True
         compressor = Compressor(self)
 
@@ -43,9 +39,7 @@ class BaseFile(ABC):
         self,
     ) -> AsyncGenerator[bytes, None]:
         if self.__used:
-            raise KeyError(
-                "ERROR: This file has already been used for streaming",
-            )
+            raise KeyError("ERROR: This file has already been used for streaming")
         self.__used = True
 
         compressor = Compressor(self)

--- a/src/zipFly/BaseFile.py
+++ b/src/zipFly/BaseFile.py
@@ -1,6 +1,6 @@
 import time
 from abc import ABC, abstractmethod
-from typing import Generator, AsyncGenerator
+from collections.abc import AsyncGenerator, Generator
 
 from . import consts
 from .Compressor import Compressor
@@ -13,14 +13,18 @@ class BaseFile(ABC):
         self.__offset = 0  # Offset to local file header
         self.__crc = 0
         self.__compression_method = compression_method or consts.NO_COMPRESSION
-        self.__flags = 0b00001000  # flag about using data descriptor is always on
+        self.__flags = (
+            0b00001000  # flag about using data descriptor is always on
+        )
 
     def __str__(self):
         return f"FILE[{self.name}]"
 
     def generate_processed_file_data(self) -> Generator[bytes, None, None]:
         if self.__used:
-            raise KeyError("ERROR: This file has already been used for streaming")
+            raise KeyError(
+                "ERROR: This file has already been used for streaming",
+            )
         self.__used = True
         compressor = Compressor(self)
 
@@ -28,16 +32,20 @@ class BaseFile(ABC):
         Generates compressed file data
         """
         for chunk in self._generate_file_data():
-            chunk = compressor.process(chunk)
+            chunk = compressor.process(chunk)  # noqa: PLW2901
             if len(chunk) > 0:
                 yield chunk
-            chunk = compressor.tail()
-            if len(chunk) > 0:
-                yield chunk
+        chunk = compressor.tail()
+        if len(chunk) > 0:
+            yield chunk
 
-    async def async_generate_processed_file_data(self) -> AsyncGenerator[bytes, None]:
+    async def async_generate_processed_file_data(
+        self,
+    ) -> AsyncGenerator[bytes, None]:
         if self.__used:
-            raise KeyError("ERROR: This file has already been used for streaming")
+            raise KeyError(
+                "ERROR: This file has already been used for streaming",
+            )
         self.__used = True
 
         compressor = Compressor(self)

--- a/src/zipFly/BaseFile.py
+++ b/src/zipFly/BaseFile.py
@@ -57,9 +57,9 @@ class BaseFile(ABC):
             chunk = compressor.process(chunk)
             if len(chunk) > 0:
                 yield chunk
-            chunk = compressor.tail()
-            if len(chunk) > 0:
-                yield chunk
+        chunk = compressor.tail()
+        if len(chunk) > 0:
+            yield chunk
 
     def get_mod_time(self) -> int:
         # Extract hours, minutes, and seconds from the modification time

--- a/tests/test_zipfly.py
+++ b/tests/test_zipfly.py
@@ -210,5 +210,7 @@ def test_multifile_archive() -> None:
                 # before any failed asserts might leave some junk
                 outs.append(tfp.read())
 
+    Path.unlink(fp.name)
+
     for out in outs:
         assert lorem_ipsum == out

--- a/tests/test_zipfly.py
+++ b/tests/test_zipfly.py
@@ -1,0 +1,214 @@
+"""Run tests of ZipFly."""
+
+import time
+import zipfile
+from collections.abc import Generator
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+from src.zipFly import GenFile, LocalFile, ZipFly, consts
+
+# ruff: noqa: S101, N802
+
+lorem_ipsum = b"""Est magni commodi voluptate consequuntur qui consequatur.
+Nam quaerat velit eum non autem laborum quae qui.
+Maxime similique qui et natus qui ut ut et.
+Quia omnis dignissimos id molestias dolores provident quis quia.
+Dicta quaerat facere molestiae. Et quod totam nihil.
+Repudiandae enim esse optio ut nostrum aliquam et cumque.
+Distinctio molestiae dolore et debitis saepe optio.
+Incidunt id quo rerum dicta dolorem.
+Eos non eum qui totam.
+Dolores laborum quibusdam fugiat temporibus sed quia voluptatem dolor.
+Fugit ut iste voluptatem dolores et vero.
+Qui quibusdam nulla distinctio.
+Numquam explicabo laboriosam delectus nemo recusandae blanditiis voluptates.
+Esse ea magnam qui ea.
+Id quo odio saepe rerum quia natus odio exercitationem.
+Deleniti sunt dolores cupiditate quia eum ab fugit.
+Similique ullam et tempore sunt incidunt ipsa.
+Molestiae est harum similique aspernatur distinctio aut."""
+
+genfile_archive_size = 1153
+localfile_archive_size = 1152
+multifile_archive_size = 5388
+
+
+def lorem_ipsum_generator() -> Generator[bytes]:
+    """Yield lines of lorem ipsum."""
+    lines = lorem_ipsum.split(b"\n")
+    # Don't yield trailing newline
+    for line in lines[:-1]:
+        yield line
+        yield b"\n"
+    yield lines[-1]
+
+
+def test_GenFile_COMPRESSION_DEFLATE() -> None:
+    """Test GenFile with compression."""
+    file1 = GenFile(
+        name="lorem_ipsum.txt",
+        generator=lorem_ipsum_generator(),
+        modification_time=time.time(),
+        size=len(lorem_ipsum) + 1,
+        compression_method=consts.COMPRESSION_DEFLATE,
+    )
+    files = [file1]
+    zip_fly = ZipFly(files)
+    # Would need to bump to Python 3.12 to get the delete_on_close
+    # parameter.
+    fp = NamedTemporaryFile(delete=False)  # noqa: SIM115
+    for chunk in zip_fly.stream():
+        fp.write(chunk)
+    fp.close()
+
+    with (
+        zipfile.ZipFile(fp.name, "r") as zfp,
+        zfp.open("lorem_ipsum.txt") as tfp,
+    ):
+        out = tfp.read()
+
+    Path.unlink(fp.name)
+
+    assert lorem_ipsum == out
+
+    assert zip_fly.calculate_archive_size() == genfile_archive_size
+
+
+def test_GenFile_NO_COMPRESSION() -> None:
+    """Test GenFile without compression."""
+    file1 = GenFile(
+        name="lorem_ipsum.txt",
+        generator=lorem_ipsum_generator(),
+        modification_time=time.time(),
+        size=len(lorem_ipsum) + 1,
+        compression_method=consts.NO_COMPRESSION,
+    )
+    files = [file1]
+    zip_fly = ZipFly(files)
+    # Would need to bump minimum to Python 3.12 to get the delete_on_close
+    # parameter and use a "with" context handler, so we'll not do that for now
+    fp = NamedTemporaryFile(delete=False)  # noqa: SIM115
+    for chunk in zip_fly.stream():
+        fp.write(chunk)
+    fp.close()
+
+    with (
+        zipfile.ZipFile(fp.name, "r") as zfp,
+        zfp.open("lorem_ipsum.txt") as tfp,
+    ):
+        out = tfp.read()
+
+    Path.unlink(fp.name)
+
+    assert lorem_ipsum == out
+
+    assert zip_fly.calculate_archive_size() == genfile_archive_size
+
+
+def test_LocalFile_COMPRESSION() -> None:
+    """Test GenFile with compression."""
+    lorem_ipsum_fp = NamedTemporaryFile(delete=False)  # noqa: SIM115
+    lorem_ipsum_fp.write(lorem_ipsum)
+    lorem_ipsum_fp.close()
+
+    file1 = LocalFile(
+        name="lorem_ipsum.txt",
+        file_path=lorem_ipsum_fp.name,
+        compression_method=consts.COMPRESSION_DEFLATE,
+    )
+    files = [file1]
+    zip_fly = ZipFly(files)
+    fp = NamedTemporaryFile(delete=False)  # noqa: SIM115
+    for chunk in zip_fly.stream():
+        fp.write(chunk)
+    fp.close()
+
+    assert zip_fly.calculate_archive_size() == localfile_archive_size
+
+    Path.unlink(lorem_ipsum_fp.name)
+
+    with (
+        zipfile.ZipFile(fp.name, "r") as zfp,
+        zfp.open("lorem_ipsum.txt") as tfp,
+    ):
+        out = tfp.read()
+
+    Path.unlink(fp.name)
+
+    assert lorem_ipsum == out
+
+
+def test_LocalFile_NO_COMPRESSION() -> None:
+    """Test GenFile without compression."""
+    lorem_ipsum_fp = NamedTemporaryFile(delete=False)  # noqa: SIM115
+    lorem_ipsum_fp.write(lorem_ipsum)
+    lorem_ipsum_fp.close()
+
+    file1 = LocalFile(
+        name="lorem_ipsum.txt",
+        file_path=lorem_ipsum_fp.name,
+        compression_method=consts.NO_COMPRESSION,
+    )
+    files = [file1]
+    zip_fly = ZipFly(files)
+    fp = NamedTemporaryFile(delete=False)  # noqa: SIM115
+    for chunk in zip_fly.stream():
+        fp.write(chunk)
+    fp.close()
+
+    assert zip_fly.calculate_archive_size() == localfile_archive_size
+
+    Path.unlink(lorem_ipsum_fp.name)
+
+    with (
+        zipfile.ZipFile(fp.name, "r") as zfp,
+        zfp.open("lorem_ipsum.txt") as tfp,
+    ):
+        out = tfp.read()
+
+    Path.unlink(fp.name)
+
+    assert lorem_ipsum == out
+
+
+def test_multifile_archive() -> None:
+    """Test adding multiple files to an archive."""
+    outnames = []
+    n_files = 5
+    for _ in range(n_files):
+        lorem_ipsum_fp = NamedTemporaryFile(delete=False)  # noqa: SIM115
+        lorem_ipsum_fp.write(lorem_ipsum)
+        lorem_ipsum_fp.close()
+        outnames.append(lorem_ipsum_fp.name)
+
+    files = []
+    for fi, outname in enumerate(outnames):
+        files.append(
+            LocalFile(
+                name=f"lorem_ipsum_{fi}.txt",
+                file_path=outname,
+                compression_method=consts.COMPRESSION_DEFLATE,
+            ),
+        )
+    zip_fly = ZipFly(files)
+    fp = NamedTemporaryFile(delete=False)  # noqa: SIM115
+    for chunk in zip_fly.stream():
+        fp.write(chunk)
+    fp.close()
+
+    assert zip_fly.calculate_archive_size() == multifile_archive_size
+
+    for outname in outnames:
+        Path.unlink(outname)
+
+    outs = []
+    with zipfile.ZipFile(fp.name, "r") as zfp:
+        for zname in zfp.filelist:
+            with zfp.open(zname.filename) as tfp:
+                # We'll test asserts later so we can delete the tempfile
+                # before any failed asserts might leave some junk
+                outs.append(tfp.read())
+
+    for out in outs:
+        assert lorem_ipsum == out

--- a/tests/test_zipfly.py
+++ b/tests/test_zipfly.py
@@ -2,9 +2,15 @@
 
 import time
 import zipfile
-from collections.abc import Generator
+from collections.abc import AsyncGenerator, Generator
 from pathlib import Path
 from tempfile import NamedTemporaryFile
+
+# Need to also have https://pypi.org/project/pytest-asyncio/ installed
+# The 4GB tests are kind of slow, this can help if you have enough memory.
+# Install this https://pypi.org/project/pytest-xdist/ and then
+# `pytest -n auto`
+import pytest
 
 from src.zipFly import GenFile, LocalFile, ZipFly, consts
 
@@ -29,8 +35,7 @@ Deleniti sunt dolores cupiditate quia eum ab fugit.
 Similique ullam et tempore sunt incidunt ipsa.
 Molestiae est harum similique aspernatur distinctio aut."""
 
-genfile_archive_size = 1153
-localfile_archive_size = 1152
+single_archive_size = 1152
 multifile_archive_size = 5388
 
 
@@ -44,13 +49,36 @@ def lorem_ipsum_generator() -> Generator[bytes]:
     yield lines[-1]
 
 
+async def lorem_ipsum_generator_async() -> AsyncGenerator[bytes]:
+    """Yield lines of lorem ipsum."""
+    for line in lorem_ipsum_generator():
+        yield line
+
+
+def sized_zeros_generator(size: int) -> Generator[bytes]:
+    """Yield zeros up to a certain size."""
+    yielded = 0
+    line = b"0" * 1024
+    while yielded < size:
+        yield line[: size - yielded]
+        yielded += len(line[: size - yielded])
+        if yielded >= size:
+            break
+
+
+async def sized_zeros_generator_async(size: int) -> AsyncGenerator[bytes]:
+    """Yield zeros up to a certain size."""
+    for zeros in sized_zeros_generator(size):
+        yield zeros
+
+
 def test_GenFile_COMPRESSION_DEFLATE() -> None:
     """Test GenFile with compression."""
     file1 = GenFile(
         name="lorem_ipsum.txt",
         generator=lorem_ipsum_generator(),
         modification_time=time.time(),
-        size=len(lorem_ipsum) + 1,
+        size=len(lorem_ipsum),
         compression_method=consts.COMPRESSION_DEFLATE,
     )
     files = [file1]
@@ -72,7 +100,39 @@ def test_GenFile_COMPRESSION_DEFLATE() -> None:
 
     assert lorem_ipsum == out
 
-    assert zip_fly.calculate_archive_size() == genfile_archive_size
+    assert zip_fly.calculate_archive_size() == single_archive_size
+
+
+@pytest.mark.asyncio
+async def test_GenFile_COMPRESSION_DEFLATE_async() -> None:
+    """Test GenFile with compression."""
+    file1 = GenFile(
+        name="lorem_ipsum.txt",
+        generator=lorem_ipsum_generator_async(),
+        modification_time=time.time(),
+        size=len(lorem_ipsum),
+        compression_method=consts.COMPRESSION_DEFLATE,
+    )
+    files = [file1]
+    zip_fly = ZipFly(files)
+    # Would need to bump to Python 3.12 to get the delete_on_close
+    # parameter.
+    fp = NamedTemporaryFile(delete=False)  # noqa: SIM115
+    async for chunk in zip_fly.async_stream():
+        fp.write(chunk)
+    fp.close()
+
+    with (
+        zipfile.ZipFile(fp.name, "r") as zfp,
+        zfp.open("lorem_ipsum.txt") as tfp,
+    ):
+        out = tfp.read()
+
+    Path.unlink(fp.name)
+
+    assert lorem_ipsum == out
+
+    assert zip_fly.calculate_archive_size() == single_archive_size
 
 
 def test_GenFile_NO_COMPRESSION() -> None:
@@ -81,7 +141,7 @@ def test_GenFile_NO_COMPRESSION() -> None:
         name="lorem_ipsum.txt",
         generator=lorem_ipsum_generator(),
         modification_time=time.time(),
-        size=len(lorem_ipsum) + 1,
+        size=len(lorem_ipsum),
         compression_method=consts.NO_COMPRESSION,
     )
     files = [file1]
@@ -103,7 +163,39 @@ def test_GenFile_NO_COMPRESSION() -> None:
 
     assert lorem_ipsum == out
 
-    assert zip_fly.calculate_archive_size() == genfile_archive_size
+    assert zip_fly.calculate_archive_size() == single_archive_size
+
+
+@pytest.mark.asyncio
+async def test_GenFile_NO_COMPRESSION_async() -> None:
+    """Test GenFile without compression."""
+    file1 = GenFile(
+        name="lorem_ipsum.txt",
+        generator=lorem_ipsum_generator_async(),
+        modification_time=time.time(),
+        size=len(lorem_ipsum),
+        compression_method=consts.NO_COMPRESSION,
+    )
+    files = [file1]
+    zip_fly = ZipFly(files)
+    # Would need to bump minimum to Python 3.12 to get the delete_on_close
+    # parameter and use a "with" context handler, so we'll not do that for now
+    fp = NamedTemporaryFile(delete=False)  # noqa: SIM115
+    async for chunk in zip_fly.async_stream():
+        fp.write(chunk)
+    fp.close()
+
+    with (
+        zipfile.ZipFile(fp.name, "r") as zfp,
+        zfp.open("lorem_ipsum.txt") as tfp,
+    ):
+        out = tfp.read()
+
+    Path.unlink(fp.name)
+
+    assert lorem_ipsum == out
+
+    assert zip_fly.calculate_archive_size() == single_archive_size
 
 
 def test_LocalFile_COMPRESSION() -> None:
@@ -124,7 +216,41 @@ def test_LocalFile_COMPRESSION() -> None:
         fp.write(chunk)
     fp.close()
 
-    assert zip_fly.calculate_archive_size() == localfile_archive_size
+    assert zip_fly.calculate_archive_size() == single_archive_size
+
+    Path.unlink(lorem_ipsum_fp.name)
+
+    with (
+        zipfile.ZipFile(fp.name, "r") as zfp,
+        zfp.open("lorem_ipsum.txt") as tfp,
+    ):
+        out = tfp.read()
+
+    Path.unlink(fp.name)
+
+    assert lorem_ipsum == out
+
+
+@pytest.mark.asyncio
+async def test_LocalFile_COMPRESSION_async() -> None:
+    """Test GenFile with compression."""
+    lorem_ipsum_fp = NamedTemporaryFile(delete=False)  # noqa: SIM115
+    lorem_ipsum_fp.write(lorem_ipsum)
+    lorem_ipsum_fp.close()
+
+    file1 = LocalFile(
+        name="lorem_ipsum.txt",
+        file_path=lorem_ipsum_fp.name,
+        compression_method=consts.COMPRESSION_DEFLATE,
+    )
+    files = [file1]
+    zip_fly = ZipFly(files)
+    fp = NamedTemporaryFile(delete=False)  # noqa: SIM115
+    async for chunk in zip_fly.async_stream():
+        fp.write(chunk)
+    fp.close()
+
+    assert zip_fly.calculate_archive_size() == single_archive_size
 
     Path.unlink(lorem_ipsum_fp.name)
 
@@ -157,7 +283,41 @@ def test_LocalFile_NO_COMPRESSION() -> None:
         fp.write(chunk)
     fp.close()
 
-    assert zip_fly.calculate_archive_size() == localfile_archive_size
+    assert zip_fly.calculate_archive_size() == single_archive_size
+
+    Path.unlink(lorem_ipsum_fp.name)
+
+    with (
+        zipfile.ZipFile(fp.name, "r") as zfp,
+        zfp.open("lorem_ipsum.txt") as tfp,
+    ):
+        out = tfp.read()
+
+    Path.unlink(fp.name)
+
+    assert lorem_ipsum == out
+
+
+@pytest.mark.asyncio
+async def test_LocalFile_NO_COMPRESSION_async() -> None:
+    """Test GenFile without compression."""
+    lorem_ipsum_fp = NamedTemporaryFile(delete=False)  # noqa: SIM115
+    lorem_ipsum_fp.write(lorem_ipsum)
+    lorem_ipsum_fp.close()
+
+    file1 = LocalFile(
+        name="lorem_ipsum.txt",
+        file_path=lorem_ipsum_fp.name,
+        compression_method=consts.NO_COMPRESSION,
+    )
+    files = [file1]
+    zip_fly = ZipFly(files)
+    fp = NamedTemporaryFile(delete=False)  # noqa: SIM115
+    async for chunk in zip_fly.async_stream():
+        fp.write(chunk)
+    fp.close()
+
+    assert zip_fly.calculate_archive_size() == single_archive_size
 
     Path.unlink(lorem_ipsum_fp.name)
 
@@ -214,3 +374,170 @@ def test_multifile_archive() -> None:
 
     for out in outs:
         assert lorem_ipsum == out
+
+
+@pytest.mark.asyncio
+async def test_multifile_archive_async() -> None:
+    """Test adding multiple files to an archive."""
+    outnames = []
+    n_files = 5
+    for _ in range(n_files):
+        lorem_ipsum_fp = NamedTemporaryFile(delete=False)  # noqa: SIM115
+        lorem_ipsum_fp.write(lorem_ipsum)
+        lorem_ipsum_fp.close()
+        outnames.append(lorem_ipsum_fp.name)
+
+    files = []
+    for fi, outname in enumerate(outnames):
+        files.append(
+            LocalFile(
+                name=f"lorem_ipsum_{fi}.txt",
+                file_path=outname,
+                compression_method=consts.COMPRESSION_DEFLATE,
+            ),
+        )
+    zip_fly = ZipFly(files)
+    fp = NamedTemporaryFile(delete=False)  # noqa: SIM115
+    async for chunk in zip_fly.async_stream():
+        fp.write(chunk)
+    fp.close()
+
+    assert zip_fly.calculate_archive_size() == multifile_archive_size
+
+    for outname in outnames:
+        Path.unlink(outname)
+
+    outs = []
+    with zipfile.ZipFile(fp.name, "r") as zfp:
+        for zname in zfp.filelist:
+            with zfp.open(zname.filename) as tfp:
+                # We'll test asserts later so we can delete the tempfile
+                # before any failed asserts might leave some junk
+                outs.append(tfp.read())
+
+    Path.unlink(fp.name)
+
+    for out in outs:
+        assert lorem_ipsum == out
+
+
+def test_4GB_GenFile_COMPRESSION_DEFLATE() -> None:
+    """Test GenFile with compression for a large file."""
+    gb4plus = 2**32 + 1024
+    file1 = GenFile(
+        name="zeros.txt",
+        # Compressing all zeros is faster than lorem ipsum and we
+        # only care that we can compress a big file.
+        generator=sized_zeros_generator(gb4plus),
+        modification_time=time.time(),
+        size=gb4plus,
+        compression_method=consts.COMPRESSION_DEFLATE,
+    )
+    files = [file1]
+    zip_fly = ZipFly(files)
+    fp = NamedTemporaryFile(delete=False)
+    for chunk in zip_fly.stream():
+        fp.write(chunk)
+    fp.close()
+
+    with (
+        zipfile.ZipFile(fp.name, "r") as zfp,
+        zfp.open("zeros.txt") as tfp,
+    ):
+        out = tfp.read()
+
+    Path.unlink(fp.name)
+
+    assert len(out) == gb4plus
+
+
+@pytest.mark.asyncio
+async def test_4GB_GenFile_COMPRESSION_DEFLATE_async() -> None:
+    """Test GenFile with compression for a large file."""
+    gb4plus = 2**32 + 1024
+    file1 = GenFile(
+        name="zeros.txt",
+        # Compressing all zeros is faster than lorem ipsum and we
+        # only care that we can compress a big file.
+        generator=sized_zeros_generator_async(gb4plus),
+        modification_time=time.time(),
+        size=gb4plus,
+        compression_method=consts.COMPRESSION_DEFLATE,
+    )
+    files = [file1]
+    zip_fly = ZipFly(files)
+    fp = NamedTemporaryFile(delete=False)
+    async for chunk in zip_fly.async_stream():
+        fp.write(chunk)
+    fp.close()
+
+    with (
+        zipfile.ZipFile(fp.name, "r") as zfp,
+        zfp.open("zeros.txt") as tfp,
+    ):
+        out = tfp.read()
+
+    Path.unlink(fp.name)
+
+    assert len(out) == gb4plus
+
+
+def test_4GB_GenFile_NO_COMPRESSION() -> None:
+    """Test GenFile without compression for a large file."""
+    gb4plus = 2**32 + 1024
+    file1 = GenFile(
+        name="zeros.txt",
+        # Compressing all zeros is faster than lorem ipsum and we
+        # only care that we can compress a big file.
+        generator=sized_zeros_generator(gb4plus),
+        modification_time=time.time(),
+        size=gb4plus,
+        compression_method=consts.NO_COMPRESSION,
+    )
+    files = [file1]
+    zip_fly = ZipFly(files)
+    fp = NamedTemporaryFile(delete=False)  # noqa: SIM115
+    for chunk in zip_fly.stream():
+        fp.write(chunk)
+    fp.close()
+
+    with (
+        zipfile.ZipFile(fp.name, "r") as zfp,
+        zfp.open("zeros.txt") as tfp,
+    ):
+        out = tfp.read()
+
+    Path.unlink(fp.name)
+
+    assert len(out) == gb4plus
+
+
+@pytest.mark.asyncio
+async def test_4GB_GenFile_NO_COMPRESSION_async() -> None:
+    """Test GenFile without compression for a large file."""
+    gb4plus = 2**32 + 1024
+    file1 = GenFile(
+        name="zeros.txt",
+        # Compressing all zeros is faster than lorem ipsum and we
+        # only care that we can compress a big file.
+        generator=sized_zeros_generator_async(gb4plus),
+        modification_time=time.time(),
+        size=gb4plus,
+        compression_method=consts.NO_COMPRESSION,
+    )
+    files = [file1]
+    zip_fly = ZipFly(files)
+    fp = NamedTemporaryFile(delete=False)  # noqa: SIM115
+    async for chunk in zip_fly.async_stream():
+        fp.write(chunk)
+    fp.close()
+
+    with (
+        zipfile.ZipFile(fp.name, "r") as zfp,
+        zfp.open("zeros.txt") as tfp,
+    ):
+        out = tfp.read()
+
+    Path.unlink(fp.name)
+
+    assert len(out) == gb4plus


### PR DESCRIPTION
The fixes are in the two functions `generate_processed_file_data` and `async_generate_processed_file_data`. The calls to `compressor.tail()` were inside the `for` loop, so `.tail()` was being called more than once. The other changes in `BaseFile.py` are autolinting changes.

I added some tests which can be run by calling `pytest` at the top level. I did not add any async tests at this time.

Finally, I updated `pyproject.toml` with changes for pytest and some linting settings for ruff.